### PR TITLE
feat: removes async function

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
 node_modules
-src

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@
 - [LICENSE](#license)
 
 ## The problem
-You want to write simple and maintainable form validations. As part of this goal, you want your validations to be simple yet accomadate your specifc needs. Be it in `React Web` or `React Native`. You should be able to add validations to more complicated components like Multi-Select, Date Time Picker. This also means it should easy to add validations with any design library you use,like [MATERIAL-UI](https://material-ui.com/), [Ant-D](https://ant.design/), [React Bootstrap](https://react-bootstrap.github.io/) etc. or even if you don't use one. You should be able to validate form from your server or any async validations for that matter.
 
+You want to write simple and maintainable form validations. As part of this goal, you want your validations to be simple yet accomadate your specifc needs. Be it in `React Web` or `React Native`. You should be able to add validations to more complicated components like Multi-Select, Date Time Picker. This also means it should easy to add validations with any design library you use,like [MATERIAL-UI](https://material-ui.com/), [Ant-D](https://ant.design/), [React Bootstrap](https://react-bootstrap.github.io/) etc. or even if you don't use one. You should be able to validate form from your server or any async validations for that matter.
 
 ## This solution
 
-The `React Use Form` is a very lightweight solution for validating forms. It provides react hooks to configure your form, in a way that encourages simpler way to validate form. It doesn't assume anything about your design. 
+The `React Use Form` is a very lightweight solution for validating forms. It provides react hooks to configure your form, in a way that encourages simpler way to validate form. It doesn't assume anything about your design.
 
 ## Installation
 
@@ -51,26 +51,25 @@ This library has `peerDependencies` listings for `react` and `react-dom`.
 
 > **NOTE: The minimum supported version of `react` is `^16.9.0`.**
 
-
 ## Examples
 
 ### Basic Example
 
 ```jsx
-import React from "react";
-import useForm from "react-hooks-form-validator";
-import { FormItem, Input, Button } from "antd";
+import React from 'react';
+import useForm from 'react-hooks-form-validator';
+import { FormItem, Input, Button } from 'antd';
 
 const formConfig = {
   username: {
     required: true,
-    min: 6
+    min: 6,
   },
   password: {
     min: 6,
     max: 20,
-    required: true
-  }
+    required: true,
+  },
 };
 
 function FormComponent() {
@@ -78,7 +77,7 @@ function FormComponent() {
   async function handleLogin() {
     await login({
       username: fields.username.value,
-      password: fields.password.value
+      password: fields.password.value,
     });
   }
 
@@ -117,15 +116,14 @@ function FormComponent() {
 }
 
 export default FormComponent;
-
 ```
 
 ### Complex Example
 
 ```jsx
-import React from "react";
-import useForm from "react-hooks-form-validator";
-import { FormItem, Input, Button } from "antd";
+import React from 'react';
+import useForm from 'react-hooks-form-validator';
+import { FormItem, Input, Button } from 'antd';
 
 const formConfig = {
   username: {
@@ -134,23 +132,21 @@ const formConfig = {
     patterns: [
       {
         regex: new RegExp(/[a-zA-Z0-9]+/),
-        errorMsg: "Please enter a only alpha numeric username"
-      }
-    ]
+        errorMsg: 'Please enter a only alpha numeric username',
+      },
+    ],
   },
   password: {
     min: 6,
     max: 20,
-    required: true
+    required: true,
   },
   confirmPassword: {
-    validationFns: [
-      (fieldValue, formValue) => {
-        const isPasswordSame = formValue.password === fieldValue;
-        return [isPasswordSame, "Password and confirm password should be same"];
-      }
-    ]
-  }
+    validate: (fieldValue, formValue) => {
+      const isPasswordSame = formValue.password === fieldValue;
+      return [isPasswordSame, 'Password and confirm password should be same'];
+    },
+  },
 };
 
 function FormComponent() {
@@ -158,7 +154,7 @@ function FormComponent() {
   async function handleLogin() {
     await login({
       username: fields.username.value,
-      password: fields.password.value
+      password: fields.password.value,
     });
   }
 
@@ -207,21 +203,22 @@ function FormComponent() {
 }
 
 export default FormComponent;
-
 ```
 
 ### More Examples
 
 You'll find runnable examples in [the `react-hooks-form-validator-examples` codesandbox](https://codesandbox.io/s/react-hooks-form-validator-examples-609ze).
 
-
 ## API Reference
+
 Basic usage is like
 
 `const` `[`[`fieldObject`](#field-object)`, `[`formObject`](#form-object)`] = useForm(`[`formConfig`](#field-config)`);`
 
 `formConfig` is object with key as `fieldName` and value as `fieldConfig`
+
 ### Example for config
+
 ```js
 {
     field1: config1,
@@ -232,39 +229,37 @@ Basic usage is like
 
 ### Field Config
 
-|      key   | What it does? | Type  | Example |
-| ------------- |:-------------:| :-------------:| -----:|
-| defaultValue  | Default value of the field | `any` | `''`, `[]`|
-| required     | To set the field as required      |   `Boolean` or `{ errorMsg : String }` | `true` or `{errorMsg: 'This is required field' }` |
-| min     | To set minimun length of field      |   `Number` or `{ errorMsg : String, length: Number}` | `5` or `{errorMsg: 'minimum of 5 character', length: 5}` |
-| max     | To set maximum length of field      |   `Number` or `{ errorMsg : String, length: Number}` | `5` or `{errorMsg: 'maximim of 5 character', length: 5}` |
-| patterns | To validate against array of patterns    |    `Array` of `{regex : RegExp, errorMsg: String}` | `[{regex: new RegExp(/[a-zA-Z0-9]+/), errorMsg: "Please enter a only alpha numeric username" }]`|
-| validationFns | To validate against array of functions/promises    |   `Array` of functions/promises `(fieldValue,formState) => [isValid, errorMessage]`  | ` [(fieldValue, formState) => [!!formState.country.id, 'Country id is mandatory']]`|
-
+| key          |             What it does?             |                        Type                         |                                                                                          Example |
+| ------------ | :-----------------------------------: | :-------------------------------------------------: | -----------------------------------------------------------------------------------------------: |
+| defaultValue |      Default value of the field       |                        `any`                        |                                                                                       `''`, `[]` |
+| required     |     To set the field as required      |        `Boolean` or `{ errorMsg : String }`         |                                                `true` or `{errorMsg: 'This is required field' }` |
+| min          |    To set minimun length of field     | `Number` or `{ errorMsg : String, length: Number}`  |                                         `5` or `{errorMsg: 'minimum of 5 character', length: 5}` |
+| max          |    To set maximum length of field     | `Number` or `{ errorMsg : String, length: Number}`  |                                         `5` or `{errorMsg: 'maximim of 5 character', length: 5}` |
+| patterns     | To validate against array of patterns |   `Array` of `{regex : RegExp, errorMsg: String}`   | `[{regex: new RegExp(/[a-zA-Z0-9]+/), errorMsg: "Please enter a only alpha numeric username" }]` |
+| validate     |         Function To validate          | `(fieldValue,formState) => [isValid, errorMessage]` |              ` [(fieldValue, formState) => [!!formState.country.id, 'Country id is mandatory']]` |
 
 ### Field Object
 
-|      key   | What it does? | Type  | 
-| ------------- |:-------------:| -----:|
-| value  | Current value of the field | any |
-| errorMsg     | Error message of the field      |`String` | 
-| isValid     | Validity of the field      |   `Boolean` |
-| setValue     | Function to set value and validate field   |   `(value) => {}`|
-| updateConfig | Function to partially update a fields config    | `(curentFieldConfig) => partialFieldConfig`|
-| validate | Function to validate the field |   `() => {}`|
-| setValueOnly | Function only set value without validating |   `(value) => {}`|
-
+| key          |                What it does?                 |                                        Type |
+| ------------ | :------------------------------------------: | ------------------------------------------: |
+| value        |          Current value of the field          |                                         any |
+| errorMsg     |          Error message of the field          |                                    `String` |
+| isValid      |            Validity of the field             |                                   `Boolean` |
+| setValue     |   Function to set value and validate field   |                             `(value) => {}` |
+| updateConfig | Function to partially update a fields config | `(curentFieldConfig) => partialFieldConfig` |
+| validate     |        Function to validate the field        |                                  `() => {}` |
+| setValueOnly |  Function only set value without validating  |                             `(value) => {}` |
 
 ### Form Object
 
-|      key   | What it does? | Type  | Example |
-| ------------- |:-------------:|:-------------:| -----:|
-| isValid     | Validity of the form      |   `Boolean` | |
-| validate | Function to validate the form |   `() => {}`| |
-| addFieldConfig  | Dynamically add a field | `fn(fieldName, fieldConfig)` or `fn(fieldName, (formState)) => fieldConfig`| `formObject.addFieldConfig('useraname', { required: true })` or `formObject.addFieldConfig('useraname', (formState) => { required: !formState.email })` |
-| removeFieldConfig  | Dynamically remove a field | `fn(fieldName)`| `formObject.removeFieldConfig('useraname')`|
-| reset     | Resets the form config before adding or removing fields      |`() => {}` | |
-| config     | Current form config   |   `{}`|
+| key               |                      What it does?                      |                                    Type                                     |                                                                                                                                                 Example |
+| ----------------- | :-----------------------------------------------------: | :-------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| isValid           |                  Validity of the form                   |                                  `Boolean`                                  |                                                                                                                                                         |
+| validate          |              Function to validate the form              |                                 `() => {}`                                  |                                                                                                                                                         |
+| addFieldConfig    |                 Dynamically add a field                 | `fn(fieldName, fieldConfig)` or `fn(fieldName, (formState)) => fieldConfig` | `formObject.addFieldConfig('useraname', { required: true })` or `formObject.addFieldConfig('useraname', (formState) => { required: !formState.email })` |
+| removeFieldConfig |               Dynamically remove a field                |                               `fn(fieldName)`                               |                                                                                                             `formObject.removeFieldConfig('useraname')` |
+| reset             | Resets the form config before adding or removing fields |                                 `() => {}`                                  |                                                                                                                                                         |
+| config            |                   Current form config                   |                                    `{}`                                     |
 
 ## LICENSE
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./dist/react-hooks-form-validator.cjs');
+} else {
+  module.exports = require('./src/index.js');
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "react-hooks-form-validator",
   "version": "3.1.0",
   "description": "One react hook for all your form validations",
-  "main": "dist/react-hooks-form-validator.cjs.js",
-  "module": "dist/react-hooks-form-validator.es.js",
+  "main": "index.js",
   "scripts": {
     "build": "rollup --config",
     "lint": "eslint src/**",
@@ -64,7 +63,7 @@
     "standard-version": "^8.0.0"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "17.0.2"
   },
   "dependencies": {
     "fastest-validator": "1.4.1"

--- a/src/__tests__/forms.spec.js
+++ b/src/__tests__/forms.spec.js
@@ -13,10 +13,9 @@ describe('Unit Test cases for use-form hook', () => {
   });
   describe('cases for automatic field validation', () => {
     it('should validate field having a required field', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({ name: { required: true } }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
       const text = 'sample';
@@ -28,7 +27,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field having a required custom required field', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({
           name: {
             required: { errorMsg: 'This is custom required error message' },
@@ -36,7 +35,6 @@ describe('Unit Test cases for use-form hook', () => {
           },
         }),
       );
-      await waitForNextUpdate();
       await act(async () => {
         await result.current[0].name.setValue('');
       });
@@ -54,10 +52,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field having a minimum length limit', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: { min: 5 } }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: { min: 5 } }));
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       const incorrectText = 'text';
@@ -76,14 +71,13 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field having a minimum length(custom error message)', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({
           name: {
             min: { length: 5, errorMsg: 'This is custom error message' },
           },
         }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       const incorrectText = 'text';
@@ -105,10 +99,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field having a maximum length limit', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: { max: 5 } }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: { max: 5 } }));
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       const incorrectText = 'superlongtext';
@@ -127,14 +118,13 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field having a maximum length limit(custom error message)', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({
           name: {
             max: { length: 5, errorMsg: 'This is custom error message' },
           },
         }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       const incorrectText = 'superlongtext';
@@ -156,7 +146,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field having a patten match', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({
           name: {
             patterns: [
@@ -168,7 +158,6 @@ describe('Unit Test cases for use-form hook', () => {
           },
         }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       const incorrectText = 'bbb';
@@ -187,19 +176,16 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field having functions as validation', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({
           name: {
-            validationFns: [
-              (nameValue, formValues) => [
-                formValues.name && formValues.name.startsWith('a'),
-                'Should is required field',
-              ],
+            validate: (nameValue, formValues) => [
+              formValues.name && formValues.name.startsWith('a'),
+              'Should is required field',
             ],
           },
         }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
       const incorrectText = 'bbb';
@@ -218,19 +204,16 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should validate field when empty value is set', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({
           name: {
-            validationFns: [
-              (nameValue, formValues) => [
-                formValues.name && formValues.name.startsWith('a'),
-                'Is a required is required field, should start with a',
-              ],
+            validate: (nameValue, formValues) => [
+              formValues.name && formValues.name.startsWith('a'),
+              'Is a required is required field, should start with a',
             ],
           },
         }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
       const correctText = 'aaa';
@@ -248,17 +231,16 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
     });
-    it('should validate field having async functions throws error', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+    it('should validate field having functions throws error', async () => {
+      const { result } = renderHook(() =>
         useForm({
           name: {
-            validationFns: [
-              jest.fn().mockRejectedValueOnce(new Error('Async error')),
-            ],
+            validate: jest.fn(() => {
+              new Error('Async error');
+            }),
           },
         }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
       const incorrectText = 'bbb';
@@ -276,20 +258,17 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
     });
-    it('should validate field having async functions as validation', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+    it('should validate field has a function as validation', async () => {
+      const { result } = renderHook(() =>
         useForm({
           name: {
-            validationFns: [
-              async (nameValue, formValues) => [
-                formValues.name && formValues.name.startsWith('a'),
-                'Should is required field',
-              ],
+            validate: (nameValue, formValues) => [
+              formValues.name && formValues.name.startsWith('a'),
+              'Should is required field',
             ],
           },
         }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
       const incorrectText = 'bbb';
@@ -308,10 +287,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should be able to manually set error on field', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       const errorText = 'Invalid Field';
@@ -326,10 +302,9 @@ describe('Unit Test cases for use-form hook', () => {
 
   describe('Cases of use-form on demand validations', () => {
     it('validate field on demand', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({ name: { required: true } }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
       const text = 'sample';
@@ -346,10 +321,9 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('validate form on demand', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({ name: { required: true } }),
       );
-      await waitForNextUpdate();
       expect(result.current[0].name.isValid).toBe(false);
       expect(result.current[1].isValid).toBe(false);
       const text = 'sample';
@@ -380,10 +354,7 @@ describe('Unit Test cases for use-form hook', () => {
   });
   describe('Cases of use-form on demand config change', () => {
     it('should set error only if field has value', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       const text = 'sample';
@@ -400,10 +371,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should throw error  if field has invalid config', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       expect(result.current[0].name.isValid).toBe(true);
       expect(result.current[1].isValid).toBe(true);
       await act(async () => {
@@ -417,20 +385,14 @@ describe('Unit Test cases for use-form hook', () => {
   });
   describe('Cases for adding new field configuration', () => {
     it('should have field config added', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       await act(async () => {
         await result.current[1].addFieldConfig('newlyAddedField', () => ({}));
       });
       expect(result.current[0].newlyAddedField).toBeDefined();
     });
     it('should accept field config as object', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       await act(async () => {
         await result.current[1].addFieldConfig('newlyAddedField', {
           defaultValue: 'Hello',
@@ -440,23 +402,17 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[0].newlyAddedField.value).toBe('Hello');
     });
     it('should throw error field config already present', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       await act(async () => {
-        await expect(
+        await expect(() =>
           result.current[1].addFieldConfig('name', () => ({})),
-        ).rejects.toEqual(
+        ).toThrow(
           Error('name already exists. Please use name.updateConfig instead'),
         );
       });
     });
     it('should invalidate a valid form if default value in invalid', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       expect(result.current[1].isValid).toBe(true);
       await act(async () => {
         await result.current[1].addFieldConfig('newlyAddedField', () => ({
@@ -467,10 +423,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[0].newlyAddedField.isValid).toBe(false);
     });
     it('should have have value field set', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       expect(result.current[1].isValid).toBe(true);
       await act(async () => {
         await result.current[1].addFieldConfig('newlyAddedField', () => ({
@@ -485,10 +438,7 @@ describe('Unit Test cases for use-form hook', () => {
   });
   describe('Cases for removing a field', () => {
     it('should be able to delete field', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       expect(result.current[0].name).toBeDefined();
       await act(async () => {
         await result.current[1].removeFieldConfig('name', () => ({}));
@@ -496,10 +446,9 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[0].name).toBeUndefined();
     });
     it('should be a valid form when invalid field is removed', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({ name: { required: true } }),
       );
-      await waitForNextUpdate();
       expect(result.current[1].isValid).toBe(false);
       await act(async () => {
         await result.current[1].removeFieldConfig('name', () => ({}));
@@ -512,10 +461,7 @@ describe('Unit Test cases for use-form hook', () => {
       const mockedWarn = jest.fn();
       // eslint-disable-next-line no-console
       console.warn = mockedWarn;
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       await act(async () => {
         await result.current[1].removeFieldConfig('randomField', () => ({}));
       });
@@ -528,10 +474,9 @@ describe('Unit Test cases for use-form hook', () => {
   });
   describe('Cases for reseting the form', () => {
     it('should reset the values', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({ name: { defaultValue: 'hello' } }),
       );
-      await waitForNextUpdate();
       expect(result.current[1].isValid).toBe(true);
       await act(async () => {
         await result.current[0].name.setValue('test');
@@ -543,10 +488,9 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[0].name.value).toBe('hello');
     });
     it('should reset the errors', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({ name: { required: true } }),
       );
-      await waitForNextUpdate();
       expect(result.current[1].isValid).toBe(false);
       await act(async () => {
         await result.current[0].name.setValue('test');
@@ -558,10 +502,7 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(false);
     });
     it('should remove the added fields', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm({ name: {} }),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm({ name: {} }));
       expect(result.current[1].isValid).toBe(true);
       await act(async () => {
         await result.current[1].addFieldConfig('newlyAddedField', () => ({
@@ -577,10 +518,9 @@ describe('Unit Test cases for use-form hook', () => {
       expect(result.current[1].isValid).toBe(true);
     });
     it('should add back the removed fields', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
+      const { result } = renderHook(() =>
         useForm({ name: {}, other: { defaultValue: 'hello' } }),
       );
-      await waitForNextUpdate();
       expect(result.current[1].isValid).toBe(true);
       await act(async () => {
         await result.current[1].removeFieldConfig('other');
@@ -598,10 +538,7 @@ describe('Unit Test cases for use-form hook', () => {
   describe('Cases for immutabilty of the form config', () => {
     const formConfig = { name: {} };
     it('should have field config added', async () => {
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useForm(formConfig),
-      );
-      await waitForNextUpdate();
+      const { result } = renderHook(() => useForm(formConfig));
       await act(async () => {
         await result.current[1].addFieldConfig('newlyAddedField', () => ({}));
       });

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,7 +43,7 @@ const PER_FIELD_CONFIG = {
     },
     optional: true,
   },
-  validationFns: { type: 'array', items: 'function', optional: true },
+  validate: { type: 'function', optional: true },
   extraInfo: { type: 'any', optional: true },
 };
 

--- a/src/use-form.js
+++ b/src/use-form.js
@@ -78,8 +78,8 @@ export default function useNewForm(fieldConfig) {
   );
 
   const validateFormFieldAndSetError = useCallback(
-    async (fieldName) => {
-      const fieldError = await getFieldError(
+    (fieldName) => {
+      const fieldError = getFieldError(
         formValuesAsRef.current,
         fieldName,
         fieldConfigRef.current,
@@ -97,8 +97,8 @@ export default function useNewForm(fieldConfig) {
     [setFieldValue, validateFormFieldAndSetError],
   );
 
-  const validateForm = useCallback(async () => {
-    const [isValid, errors] = await getFormErrors(
+  const validateForm = useCallback(() => {
+    const [isValid, errors] = getFormErrors(
       fieldConfigRef.current,
       formValuesAsRef.current,
     );
@@ -133,7 +133,7 @@ export default function useNewForm(fieldConfig) {
   );
 
   const addFieldConfig = useCallback(
-    async (fieldName, fieldConfigOrUpdater) => {
+    (fieldName, fieldConfigOrUpdater) => {
       const isFieldAlreadPresent = !!fieldConfigRef.current[fieldName];
       if (isFieldAlreadPresent) {
         const error = new Error(
@@ -155,7 +155,7 @@ export default function useNewForm(fieldConfig) {
     [setFieldValue, validateFieldAndSetErrorIfValueExists],
   );
 
-  const removeFieldConfig = useCallback(async (fieldName) => {
+  const removeFieldConfig = useCallback((fieldName) => {
     const isFieldAlreadPresent = !!fieldConfigRef.current[fieldName];
     if (!isFieldAlreadPresent) {
       // eslint-disable-next-line no-console
@@ -179,8 +179,8 @@ export default function useNewForm(fieldConfig) {
     return fieldConfigRef.current;
   }, []);
 
-  const setFormErrorWithoutMessages = useCallback(async () => {
-    const [, errorFields] = await getFormErrors(
+  const setFormErrorWithoutMessages = useCallback(() => {
+    const [, errorFields] = getFormErrors(
       fieldConfigRef.current,
       formValuesAsRef.current,
     );
@@ -235,7 +235,7 @@ export default function useNewForm(fieldConfig) {
         },
         get isValid() {
           /**
-           * Validation happens async, so there is a possibility that `formErrors[fieldName]` is not defined yet.
+           *
            * So by default, for that duration isValid is false
            */
           return (

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -29,21 +29,12 @@ export function getDefaultErrors(formFieldConfig) {
   return defaultErrors;
 }
 
-export async function getFieldError(formState, fieldName, formFieldConfig) {
-  const { required, min, max, patterns, validationFns } = formFieldConfig[
-    fieldName
-  ];
+export function getFieldError(formState, fieldName, formFieldConfig) {
+  const { required, min, max, patterns, validate } = formFieldConfig[fieldName];
   const fieldValue = formState[fieldName];
-  if (validationFns && validationFns.length) {
+  if (validate) {
     try {
-      const validationResults = await Promise.all(
-        validationFns.map((asyncValidationFn) =>
-          asyncValidationFn(formState[fieldName], formState),
-        ),
-      );
-      const [valid, errorMsg] = validationResults.find(
-        ([validationStatus]) => !validationStatus,
-      ) || [true];
+      const [valid, errorMsg] = validate(formState[fieldName], formState);
       if (!valid) {
         return errorMsg || 'Invalid input';
       }
@@ -122,13 +113,11 @@ export function getFormValidity(formErrors) {
   );
 }
 
-export async function getFormErrors(fieldConfig, formValues) {
+export function getFormErrors(fieldConfig, formValues) {
   const errors = {};
   const allFieldsNames = Object.keys(fieldConfig);
-  const validationResults = await Promise.all(
-    allFieldsNames.map(async (fieldName) =>
-      getFieldError(formValues, fieldName, fieldConfig),
-    ),
+  const validationResults = allFieldsNames.map((fieldName) =>
+    getFieldError(formValues, fieldName, fieldConfig),
   );
   validationResults.forEach((errorMsg, index) => {
     const fieldName = allFieldsNames[index];


### PR DESCRIPTION
BREAKING CHANGE: removes support for async validations, accepts single function `validate` instead of `validationFns`